### PR TITLE
support kustomization of the controller manifest

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- manifests/system-upgrade-controller.yaml
+images:
+- name: rancher/system-upgrade-controller
+  newTag: v0.1.0
+- name: rancher/kubectl
+  newTag: v1.17.0


### PR DESCRIPTION
Supports running kustomize at the repository root to generate working controller deployment manifest.