### PR TITLE
per-plan service account name

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func Run(c *cli.Context) {
 		logrus.Fatal(err)
 	}
 	ctx := signals.SetupSignalHandler(context.Background())
-	if err := upgrade.StartController(ctx, cfg, threads, namespace, serviceAccountName, name); err != nil {
+	if err := upgrade.StartController(ctx, cfg, threads, namespace, name); err != nil {
 		logrus.Fatalf("Error starting: %v", err)
 	}
 	<-ctx.Done()

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -30,8 +30,9 @@ type Plan struct {
 
 // PlanSpec represents the user-configurable details of a Plan
 type PlanSpec struct {
-	Concurrency  int64                 `json:"concurrency,omitempty"`
-	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	Concurrency        int64                 `json:"concurrency,omitempty"`
+	NodeSelector       *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	ServiceAccountName string                `json:"serviceAccountName,omitempty"`
 
 	Channel string       `json:"channel,omitempty"`
 	Version string       `json:"version,omitempty"`

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -74,7 +74,7 @@ func UpgradeImage(plan *upgradeapiv1.Plan) string {
 	return image + `:` + plan.Status.LatestVersion
 }
 
-func NewUpgradeJob(plan *upgradeapiv1.Plan, serviceAccountName, nodeName, controllerName string) *batchv1.Job {
+func NewUpgradeJob(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job {
 	hostPathDirectory := corev1.HostPathDirectory
 	labelPlanName := upgradeapi.LabelPlanName(plan.Name)
 	job := &batchv1.Job{
@@ -102,7 +102,7 @@ func NewUpgradeJob(plan *upgradeapiv1.Plan, serviceAccountName, nodeName, contro
 				Spec: corev1.PodSpec{
 					HostIPC:            true,
 					HostPID:            true,
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: plan.Spec.ServiceAccountName,
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -14,7 +14,7 @@ import (
 )
 
 // StartController starts the controller
-func StartController(ctx context.Context, config *rest.Config, threads int, namespace, serviceAccountName, name string) error {
+func StartController(ctx context.Context, config *rest.Config, threads int, namespace, name string) error {
 	if crdFactory, err := crd.NewFactoryFromClient(config); err != nil {
 		return err
 	} else if err = plan.RegisterCRD(ctx, crdFactory); err != nil {
@@ -41,7 +41,7 @@ func StartController(ctx context.Context, config *rest.Config, threads int, name
 		return err
 	}
 
-	err = plan.RegisterHandlers(ctx, serviceAccountName, namespace, name, apply, upgradeFactory, coreFactory, batchFactory)
+	err = plan.RegisterHandlers(ctx, namespace, name, apply, upgradeFactory, coreFactory, batchFactory)
 	if err != nil {
 		return err
 	}

--- a/scripts/build
+++ b/scripts/build
@@ -7,7 +7,6 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
-PKG=github.com/rancher/system-upgrade-controller
 echo "Building $PKG ..."
 VERSIONFLAGS="-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.GitCommit=${COMMIT:0:8}"
 CGO_ENABLED=0 go build -ldflags "$VERSIONFLAGS $LINKFLAGS" -o bin/system-upgrade-controller

--- a/scripts/package
+++ b/scripts/package
@@ -1,4 +1,12 @@
 #!/bin/bash
 set -e
 
+source $(dirname $0)/version
+
+DIST=$(dirname $0)/../dist/artifacts
+echo "Copying binaries to ${DIST} ..."
+mkdir -vp "${DIST}"
+cp -vf $(dirname $0)/../bin/system-upgrade-controller "${DIST}/system-upgrade-controller-${ARCH}"
+
+echo "Packaging ${REPO}/system-upgrade-controller ..."
 $(dirname $0)/package-controller

--- a/scripts/package-controller
+++ b/scripts/package-controller
@@ -3,24 +3,23 @@ set -e
 
 source $(dirname $0)/version
 
-ARCH=${ARCH:-"amd64"}
-SUFFIX=""
-[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
-
 cd $(dirname $0)/..
 
-TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rancher}
-
-if echo $TAG | grep -q dirty; then
-    TAG=dev
+if [ "$ARCH" != "arm" ]; then
+    export DOCKER_BUILDKIT=1
 fi
 
-IMAGE=${REPO}/system-upgrade-controller:${TAG}
-docker image build -t ${IMAGE} -f ./package/Dockerfile .
-docker image tag ${IMAGE} ${REPO}/system-upgrade-controller:latest
+docker build \
+  --build-arg ARCH=${ARCH} \
+  --build-arg REPO=${REPO} \
+  --build-arg TAG=${TAG} \
+  --build-arg VERSION=${VERSION} \
+  --file package/Dockerfile \
+  --tag ${REPO}/system-upgrade-controller:${TAG} \
+  --tag ${REPO}/system-upgrade-controller:latest \
+.
 docker image save --output ./dist/images.tar \
   ${REPO}/system-upgrade-controller:${TAG} \
   ${REPO}/system-upgrade-controller:latest
-echo ${IMAGE} > ./dist/images.txt
-echo Built ${IMAGE} and ${REPO}/system-upgrade-controller:latest
+echo ${REPO}/system-upgrade-controller:${TAG} > ./dist/images.txt
+echo Built ${REPO}/system-upgrade-controller:${TAG}

--- a/scripts/test
+++ b/scripts/test
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
+source $(dirname $0)/version
+
 cd $(dirname $0)/..
 
-
-echo "Running tests"
+echo "Testing $PKG ..."
 go test -cover -tags=test ./pkg/...

--- a/scripts/version
+++ b/scripts/version
@@ -16,3 +16,13 @@ fi
 if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
 fi
+
+ARCH=${ARCH:-"amd64"}
+TAG=${TAG:-"${VERSION}-${ARCH}"}
+REPO=${REPO:-rancher}
+
+if echo $TAG | grep -q dirty; then
+    TAG=dev
+fi
+
+PKG=github.com/rancher/system-upgrade-controller


### PR DESCRIPTION
The controller's service account is no longer utilized for upgrade jobs. This means that, unless specified on the **Plan**, upgrade jobs will get the `default` service account for the namespace.

Fixes #7 

P.S. Also lumped in here are some build script changes.