### PR TITLE
reconcile failed jobs with delete

### DIFF
--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -11,6 +11,7 @@ import (
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	upgradecln "github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned"
 	upgradescheme "github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme"
+	upgradejob "github.com/rancher/system-upgrade-controller/pkg/upgrade/job"
 	"github.com/rancher/wrangler/pkg/condition"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -130,9 +131,6 @@ func (c *Client) WaitForPlanCondition(name string, cond condition.Cond, timeout 
 }
 
 func (c *Client) WaitForPlanJobs(plan *upgradeapiv1.Plan, count int, timeout time.Duration) (jobs []batchv1.Job, err error) {
-	complete := condition.Cond(batchv1.JobComplete)
-	failed := condition.Cond(batchv1.JobFailed)
-
 	labelSelector := labels.SelectorFromSet(labels.Set{
 		upgradeapi.LabelPlan: plan.Name,
 	})
@@ -145,7 +143,7 @@ func (c *Client) WaitForPlanJobs(plan *upgradeapiv1.Plan, count int, timeout tim
 			return false, err
 		}
 		for _, item := range list.Items {
-			if failed.IsTrue(&item) || complete.IsTrue(&item) {
+			if upgradejob.ConditionFailed.IsTrue(&item) || upgradejob.ConditionComplete.IsTrue(&item) {
 				jobs = append(jobs, item)
 			}
 		}

--- a/pkg/apis/upgrade.cattle.io/constants.go
+++ b/pkg/apis/upgrade.cattle.io/constants.go
@@ -12,7 +12,7 @@ const (
 	// LabelPlan is the plan being applied.
 	LabelPlan = GroupName + `/plan`
 
-	// LabelPlan is the version being applied.
+	// LabelVersion is the version of the plan being applied.
 	LabelVersion = GroupName + `/version`
 
 	// LabelPlanSuffix is used for composing labels specific to a plan.

--- a/pkg/upgrade/handle_batch.go
+++ b/pkg/upgrade/handle_batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	upgradeapi "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
+	upgradejob "github.com/rancher/system-upgrade-controller/pkg/upgrade/job"
 	batchv1 "k8s.io/api/batch/v1"
 )
 
@@ -18,8 +19,8 @@ func (ctl *Controller) handleJobs(ctx context.Context) error {
 		}
 		if obj.Labels != nil {
 			if planName, ok := obj.Labels[upgradeapi.LabelPlan]; ok {
-				defer plans.Enqueue(obj.Namespace, planName)
-				if obj.Status.Succeeded == 1 {
+				if upgradejob.ConditionComplete.IsTrue(obj) {
+					defer plans.Enqueue(obj.Namespace, planName)
 					planLabel := upgradeapi.LabelPlanName(planName)
 					if planHash, ok := obj.Labels[planLabel]; ok {
 						if nodeName, ok := obj.Labels[upgradeapi.LabelNode]; ok {

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -7,6 +7,7 @@ import (
 	upgradeapi "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	upgradectr "github.com/rancher/system-upgrade-controller/pkg/upgrade/container"
+	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
@@ -70,6 +71,11 @@ var (
 		}
 		return defaultValue
 	}(defaultImagePullPolicy)
+)
+
+var (
+	ConditionComplete = condition.Cond(batchv1.JobComplete)
+	ConditionFailed   = condition.Cond(batchv1.JobFailed)
 )
 
 func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job {
@@ -253,6 +259,5 @@ func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job 
 		}
 	}
 
-	//batchobjv1.SetObjectDefaults_Job(job)
 	return job
 }

--- a/pkg/upgrade/job/job_reconcile.go
+++ b/pkg/upgrade/job/job_reconcile.go
@@ -1,0 +1,57 @@
+package job
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/rancher/wrangler/pkg/apply"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Reconciler returns values suitable for use in apply.WithReconciler
+func Reconciler() (schema.GroupVersionKind, apply.Reconciler) {
+	convert := func(src interface{}, obj interface{}) error {
+		u, ok := src.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("expected unstructured but got %v", reflect.TypeOf(src))
+		}
+		bytes, err := u.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(bytes, obj)
+	}
+	// adapted from wrangler's apply.reconcileJob
+	return batchv1.SchemeGroupVersion.WithKind("Job"), func(oldObj runtime.Object, newObj runtime.Object) (b bool, err error) {
+		oldJob, ok := oldObj.(*batchv1.Job)
+		if !ok {
+			oldJob = &batchv1.Job{}
+			if err := convert(oldObj, oldJob); err != nil {
+				return false, err
+			}
+		}
+
+		if ConditionFailed.IsTrue(oldJob) {
+			return false, apply.ErrReplace
+		}
+
+		newJob, ok := newObj.(*batchv1.Job)
+		if !ok {
+			newJob = &batchv1.Job{}
+			if err := convert(newObj, newJob); err != nil {
+				return false, err
+			}
+		}
+
+		if !equality.Semantic.DeepEqual(oldJob.Spec.Template, newJob.Spec.Template) {
+			return false, apply.ErrReplace
+		}
+
+		return false, nil
+	}
+}


### PR DESCRIPTION
Implements job retry on failure by adapting the wrangler default job reconciler to delete an existing job if it has failed.

Further mitigates rancher/rancher#25882 (by ensuring that upgrades are kept on the treadmill)