### PR TITLE
save the ttlSecondsAfterFinished in an annotation

### DIFF
--- a/pkg/apis/upgrade.cattle.io/constants.go
+++ b/pkg/apis/upgrade.cattle.io/constants.go
@@ -3,6 +3,9 @@ package upgrade
 import "path"
 
 const (
+	// AnnotationTTLSecondsAfterFinished is used to store a fallback value for job.spec.ttlSecondsAfterFinished
+	AnnotationTTLSecondsAfterFinished = GroupName + `/ttl-seconds-after-finished`
+
 	// LabelController is the name of the upgrade controller.
 	LabelController = GroupName + `/controller`
 

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -97,6 +97,9 @@ func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName("apply", plan.Name, "on", nodeName, "with", plan.Status.LatestHash),
 			Namespace: plan.Namespace,
+			Annotations: labels.Set{
+				upgradeapi.AnnotationTTLSecondsAfterFinished: strconv.FormatInt(int64(TTLSecondsAfterFinished), 10),
+			},
 			Labels: labels.Set{
 				upgradeapi.LabelController: controllerName,
 				upgradeapi.LabelNode:       nodeName,


### PR DESCRIPTION
This should help guarantee that completed jobs get deleted by mitigating an aggressive controller removing the `ttlSecondsAfterFinished` from the job spec.

Addresses rancher/rancher#25929
Addresses #24 