### PR TITLE
(#59) Do not overwrite container image tag if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ spec:
     force: true
 
   upgrade:
-    # The tag portion of the image will be overridden with the value from `.status.latestVersion` a.k.a. the resolved version.
+    # If not present, the tag portion of the image will be the value from `.status.latestVersion` a.k.a. the resolved version.
     # SEE https://github.com/rancher/system-upgrade-controller/blob/v0.1.0/pkg/apis/upgrade.cattle.io/v1/types.go#L47
     image: rancher/k3os
     command: [k3os, --debug]

--- a/examples/ubuntu/bionic/linux-aws-kernel.yaml
+++ b/examples/ubuntu/bionic/linux-aws-kernel.yaml
@@ -71,7 +71,7 @@ spec:
 
   # A very limited container spec
   upgrade:
-    # The tag portion of the image will be overridden with the value from `.status.latestVersion` a.k.a. the resolved version.
+    # If not present, the tag of the image will be the value from `.status.latestVersion` a.k.a. the resolved version.
     image: ubuntu
     command: ["chroot", "/host"]
     args: ["sh", "/run/system-upgrade/secrets/kernel/upgrade.sh"]

--- a/pkg/upgrade/container/container.go
+++ b/pkg/upgrade/container/container.go
@@ -46,7 +46,7 @@ func WithImageTag(tag string) Option {
 	return func(container *corev1.Container) {
 		image := container.Image
 		if p := strings.Split(image, `:`); len(p) > 1 {
-			image = strings.Join(p[0:len(p)-1], `:`)
+			return
 		}
 		container.Image = image + `:` + tag
 	}

--- a/pkg/upgrade/container/container_test.go
+++ b/pkg/upgrade/container/container_test.go
@@ -43,22 +43,24 @@ var _ = Describe("Container", func() {
 			BeforeEach(func() {
 				testOption = container.WithImageTag(testImageTag)
 			})
-			for _, image := range []string{
-				testImageInfix,
-				testImageInfix + ":latest",
-				filepath.Join(testRepository, testImageInfix),
-				filepath.Join(testRepository, testImageInfix+":latest"),
+			for _, image := range []struct {
+				img    string
+				suffix string
+			}{
+				{testImageInfix, testImageInfix + `:` + testImageTag},
+				{testImageInfix + ":latest", testImageInfix + ":latest"},
+				{filepath.Join(testRepository, testImageInfix), testImageInfix + `:` + testImageTag},
+				{filepath.Join(testRepository, testImageInfix+":latest"), testImageInfix + ":latest"},
 			} {
-				When("image is `"+image+"` and tag is `"+testImageTag+"` ", func() {
-					var suffix = testImageInfix + `:` + testImageTag
+				When("image is `"+image.img+"` and tag is `"+testImageTag+"` ", func() {
 					BeforeEach(func() {
-						testContainer.Image = image
+						testContainer.Image = image.img
 						testOption(&testContainer) // apply the option
 						*zeroContainer = testContainer
 						zeroContainer.Image = ""
 					})
 					It("should have correct image suffix with no other side effects", func() {
-						Expect(testContainer.Image).To(HaveSuffix(suffix))
+						Expect(testContainer.Image).To(HaveSuffix(image.suffix))
 						Expect(*zeroContainer).To(BeZero())
 					})
 				})


### PR DESCRIPTION
The current behavior is to force the upgrade container image tag
to be overwritten by status.lastVersion.
While this works for some workflows, it prevents workflows where the
upgrade is done in a non versioned image (or that always requires
latest for instance), because it becomes impossible to mention a
given specific image tag (and especially when using channel instead
of a specific Plan version).

This change implements the following behavior:
* if the image is not specified with a tag, the status.lastVersion
is used, as before.
* if the image specifies a tag, then this tag is used