### PR TITLE
latest tag for prepare and upgrade containers

### DIFF
--- a/examples/k3s-upgrade.yaml
+++ b/examples/k3s-upgrade.yaml
@@ -2,17 +2,19 @@
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
-  name: k3s-master
+  name: k3s-server
   namespace: system-upgrade
+  labels:
+    k3s-upgrade: server
 spec:
   concurrency: 1
-  version: v1.17.3+k3s1
+  version: v1.17.4+k3s1
   nodeSelector:
-    matchLabels:
-      node.kubernetes.io/instance-type: k3s
     matchExpressions:
       - {key: k3s-upgrade, operator: Exists}
       - {key: k3s-upgrade, operator: NotIn, values: ["disabled", "false"]}
+      - {key: k3s.io/hostname, operator: Exists}
+      - {key: k3os.io/mode, operator: DoesNotExist}
       - {key: node-role.kubernetes.io/master, operator: In, values: ["true"]}
   serviceAccountName: system-upgrade
   cordon: true
@@ -24,22 +26,24 @@ spec:
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
-  name: k3s-worker
+  name: k3s-agent
   namespace: system-upgrade
+  labels:
+    k3s-upgrade: agent
 spec:
   concurrency: 2
-  version: v1.17.3+k3s1
+  version: v1.17.4+k3s1
   nodeSelector:
-    matchLabels:
-      node.kubernetes.io/instance-type: k3s
     matchExpressions:
       - {key: k3s-upgrade, operator: Exists}
       - {key: k3s-upgrade, operator: NotIn, values: ["disabled", "false"]}
+      - {key: k3s.io/hostname, operator: Exists}
+      - {key: k3os.io/mode, operator: DoesNotExist}
       - {key: node-role.kubernetes.io/master, operator: NotIn, values: ["true"]}
   serviceAccountName: system-upgrade
   prepare:
-    image: rancher/k3s-upgrade:v1.17.3-k3s1
-    args: ["prepare", "k3s-master"]
+    image: rancher/k3s-upgrade:v1.17.4-k3s1
+    args: ["prepare", "k3s-server"]
   drain:
     force: true
   upgrade:

--- a/examples/ubuntu/bionic.md
+++ b/examples/ubuntu/bionic.md
@@ -85,7 +85,7 @@ With a `.spec.concurrency` of `2` you should see no more than that number of nod
 
 ## k3s
 
-As a bonus, because we are running K3s, I have included two plans in [`k3s.yaml`](k3s.yaml) that are made available to
+As a bonus, because we are running K3s, I have included two plans in [`../k3s-upgrade.yaml`](../k3s-upgrade.yaml) that are made available to
 the cluster and activated by running `docker exec -it kubectl label node --all k3s-upgrade=enabled`. These two plans
 coordinate to upgrade all of the masters with a concurrency of 1 and then all of the workers with a concurrency of 2.
 See https://github.com/rancher/k3s-upgrade, written by https://github.com/galal-hussein.

--- a/examples/ubuntu/docker-compose.yaml
+++ b/examples/ubuntu/docker-compose.yaml
@@ -28,8 +28,8 @@ services:
       - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/bionic.yaml
         source: ./bionic.yaml
         type: bind
-      - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/k3s.yaml
-        source: ./k3s.yaml
+      - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/k3s-upgrade.yaml
+        source: ../k3s-upgrade.yaml
         type: bind
 
   master:
@@ -56,8 +56,8 @@ services:
       - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/bionic.yaml
         source: ./bionic.yaml
         type: bind
-      - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/k3s.yaml
-        source: ./k3s.yaml
+      - target: /var/lib/rancher/k3s/server/manifests/system-upgrade-plans/k3s-upgrade.yaml
+        source: ../k3s-upgrade.yaml
         type: bind
 
   worker:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rancher/system-upgrade-controller
 go 1.13
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/rancher/wrangler v0.5.4-0.20200326191509-4054411d9736

--- a/pkg/upgrade/container/container_test.go
+++ b/pkg/upgrade/container/container_test.go
@@ -1,8 +1,6 @@
 package container_test
 
 import (
-	"path/filepath"
-
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/rancher/system-upgrade-controller/pkg/upgrade/container"
 	corev1 "k8s.io/api/core/v1"
@@ -20,131 +18,161 @@ var _ = Describe("Container", func() {
 		Expect(zeroContainer).To(Equal(&testContainer))
 		Expect(testContainer).To(BeZero())
 	})
-	Describe("Applying Options", func() {
-		Context("WithImagePullPolicy", func() {
-			const testPullPolicy = corev1.PullPolicy("OnlyWhenTesting")
+
+	Context("WithImagePullPolicy", func() {
+		const testPullPolicy = corev1.PullPolicy("OnlyWhenTesting")
+		BeforeEach(func() {
+			testOption = container.WithImagePullPolicy(testPullPolicy)
+			Expect(testContainer.ImagePullPolicy).To(BeEmpty())
+			testOption(&testContainer) // apply the option
+			*zeroContainer = testContainer
+			zeroContainer.ImagePullPolicy = ""
+		})
+		It("should have ImagePullPolicy with no side effects", func() {
+			Expect(testContainer.ImagePullPolicy).To(Equal(testPullPolicy))
+			Expect(*zeroContainer).To(BeZero())
+		})
+	})
+
+	Context("WithLatestTag", func() {
+		const testImageRegistry = "img.example.com:5000"
+		const testImagePath = "test/image"
+		const testImageTag = "test"
+		BeforeEach(func() {
+			testOption = container.WithLatestTag(testImageTag)
+		})
+		When("image ref is without domain and tag, e.g. "+testImagePath, func() {
 			BeforeEach(func() {
-				testOption = container.WithImagePullPolicy(testPullPolicy)
-				Expect(testContainer.ImagePullPolicy).To(BeEmpty())
+				testContainer.Image = testImagePath
 				testOption(&testContainer) // apply the option
 				*zeroContainer = testContainer
-				zeroContainer.ImagePullPolicy = ""
+				zeroContainer.Image = ""
 			})
-			It("should have ImagePullPolicy with no side effects", func() {
-				Expect(testContainer.ImagePullPolicy).To(Equal(testPullPolicy))
+			It("should have tag override with no side effects", func() {
+				Expect(testContainer.Image).To(Equal(testImagePath + `:` + testImageTag))
 				Expect(*zeroContainer).To(BeZero())
 			})
 		})
-
-		Context("WithImageTag", func() {
-			const testRepository = "img.example.com:5000"
-			const testImageInfix = "this/is/a/test/image"
-			const testImageTag = "test"
+		const imageWithoutDomainWithTag = testImagePath + `:test-with-image-tag`
+		When("image ref is without domain but with tag, e.g. "+imageWithoutDomainWithTag, func() {
 			BeforeEach(func() {
-				testOption = container.WithImageTag(testImageTag)
+				testContainer.Image = imageWithoutDomainWithTag
+				testOption(&testContainer) // apply the option
+				*zeroContainer = testContainer
+				zeroContainer.Image = ""
 			})
-			for _, image := range []string{
-				testImageInfix,
-				testImageInfix + ":latest",
-				filepath.Join(testRepository, testImageInfix),
-				filepath.Join(testRepository, testImageInfix+":latest"),
-			} {
-				When("image is `"+image+"` and tag is `"+testImageTag+"` ", func() {
-					var suffix = testImageInfix + `:` + testImageTag
-					BeforeEach(func() {
-						testContainer.Image = image
-						testOption(&testContainer) // apply the option
-						*zeroContainer = testContainer
-						zeroContainer.Image = ""
-					})
-					It("should have correct image suffix with no other side effects", func() {
-						Expect(testContainer.Image).To(HaveSuffix(suffix))
-						Expect(*zeroContainer).To(BeZero())
-					})
+			It("should have no side effects", func() {
+				Expect(testContainer.Image).To(Equal(imageWithoutDomainWithTag))
+				Expect(*zeroContainer).To(BeZero())
+			})
+		})
+		const imageWithDomainWithoutTag = testImageRegistry + `/` + testImagePath
+		When("image ref with domain and without tag, e.g. "+imageWithDomainWithoutTag, func() {
+			BeforeEach(func() {
+				testContainer.Image = imageWithDomainWithoutTag
+				testOption(&testContainer) // apply the option
+				*zeroContainer = testContainer
+				zeroContainer.Image = ""
+			})
+			It("should have overridden tag with no side effects", func() {
+				Expect(testContainer.Image).To(Equal(imageWithDomainWithoutTag + `:` + testImageTag))
+				Expect(*zeroContainer).To(BeZero())
+			})
+		})
+		const imageWithDomainAndTag = testImageRegistry + `/` + testImagePath + `:test-with-image-tag`
+		When("image ref with domain and tag, e.g. "+imageWithDomainAndTag, func() {
+			BeforeEach(func() {
+				testContainer.Image = imageWithDomainAndTag
+				testOption(&testContainer) // apply the option
+				*zeroContainer = testContainer
+				zeroContainer.Image = ""
+			})
+			It("should have no side effects", func() {
+				Expect(testContainer.Image).To(Equal(imageWithDomainAndTag))
+				Expect(*zeroContainer).To(BeZero())
+			})
+		})
+	})
+
+	Context("WithPlanEnvironment", func() {
+		var testPlanStatus = upgradeapiv1.PlanStatus{
+			LatestVersion: "test",
+			LatestHash:    "test-hash",
+		}
+		BeforeEach(func() {
+			testOption = container.WithPlanEnvironment("test", testPlanStatus)
+			Expect(testContainer.Env).To(BeEmpty())
+			testOption(&testContainer) // apply the option
+			*zeroContainer = testContainer
+			zeroContainer.Env = nil
+		})
+		It("should have Env with no side effects", func() {
+			Expect(testContainer.Env).ToNot(BeEmpty())
+			Expect(*zeroContainer).To(BeZero())
+		})
+
+	})
+
+	Context("WithSecrets", func() {
+		var (
+			testSecretHavingPath = upgradeapiv1.SecretSpec{
+				Name: "having-path", Path: "/run/secret/having-path",
+			}
+			testSecretNotHavingPath = upgradeapiv1.SecretSpec{
+				Name: "not-having-path",
+			}
+			testSecretHavingLongName = upgradeapiv1.SecretSpec{
+				Name: "not-having-path-with-a-supercalifragilisticexpialidocious-name",
+			}
+			testSecrets = []upgradeapiv1.SecretSpec{
+				testSecretHavingPath, testSecretNotHavingPath, testSecretHavingLongName,
+			}
+		)
+		BeforeEach(func() {
+			testOption = container.WithSecrets(testSecrets)
+			Expect(testContainer.VolumeMounts).To(BeEmpty())
+			testOption(&testContainer) // apply the option
+			*zeroContainer = testContainer
+			zeroContainer.VolumeMounts = nil
+		})
+		It("should have VolumeMounts with no side effects", func() {
+			Expect(testContainer.VolumeMounts).To(HaveLen(len(testSecrets)))
+			Expect(*zeroContainer).To(BeZero())
+			for i, testSecret := range testSecrets {
+				By("having VolumeMount for Secret `"+testSecret.Name+"`", func() {
+					if len(testSecret.Name) > 50 {
+						Expect(testContainer.VolumeMounts[i].Name).To(ContainSubstring(testSecret.Name[:50]))
+					} else {
+						Expect(testContainer.VolumeMounts[i].Name).To(HaveSuffix(testSecret.Name))
+					}
+					if testSecret.Path != "" {
+						Expect(testContainer.VolumeMounts[i].MountPath).To(Equal(testSecret.Path))
+					}
 				})
 			}
 		})
+	})
 
-		Context("WithPlanEnvironment", func() {
-			var testPlanStatus = upgradeapiv1.PlanStatus{
-				LatestVersion: "test",
-				LatestHash:    "test-hash",
-			}
-			BeforeEach(func() {
-				testOption = container.WithPlanEnvironment("test", testPlanStatus)
-				Expect(testContainer.Env).To(BeEmpty())
-				testOption(&testContainer) // apply the option
-				*zeroContainer = testContainer
-				zeroContainer.Env = nil
-			})
-			It("should have Env with no side effects", func() {
-				Expect(testContainer.Env).ToNot(BeEmpty())
-				Expect(*zeroContainer).To(BeZero())
-			})
-
-		})
-
-		Context("WithSecrets", func() {
-			var (
-				testSecretHavingPath = upgradeapiv1.SecretSpec{
-					Name: "having-path", Path: "/run/secret/having-path",
-				}
-				testSecretNotHavingPath = upgradeapiv1.SecretSpec{
-					Name: "not-having-path",
-				}
-				testSecretHavingLongName = upgradeapiv1.SecretSpec{
-					Name: "not-having-path-with-a-supercalifragilisticexpialidocious-name",
-				}
-				testSecrets = []upgradeapiv1.SecretSpec{
-					testSecretHavingPath, testSecretNotHavingPath, testSecretHavingLongName,
-				}
-			)
-			BeforeEach(func() {
-				testOption = container.WithSecrets(testSecrets)
-				Expect(testContainer.VolumeMounts).To(BeEmpty())
-				testOption(&testContainer) // apply the option
-				*zeroContainer = testContainer
-				zeroContainer.VolumeMounts = nil
-			})
-			It("should have VolumeMounts with no side effects", func() {
-				Expect(testContainer.VolumeMounts).To(HaveLen(len(testSecrets)))
-				Expect(*zeroContainer).To(BeZero())
-				for i, testSecret := range testSecrets {
-					By("having VolumeMount for Secret `"+testSecret.Name+"`", func() {
-						if len(testSecret.Name) > 50 {
-							Expect(testContainer.VolumeMounts[i].Name).To(ContainSubstring(testSecret.Name[:50]))
-						} else {
-							Expect(testContainer.VolumeMounts[i].Name).To(HaveSuffix(testSecret.Name))
-						}
-						if testSecret.Path != "" {
-							Expect(testContainer.VolumeMounts[i].MountPath).To(Equal(testSecret.Path))
-						}
-					})
-				}
-			})
-		})
-
-		Context("WithSecurityContext", func() {
-			var privileged = true
-			var testSecurityContext corev1.SecurityContext = corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{
-						"TEST_CONTAINER",
-					},
+	Context("WithSecurityContext", func() {
+		var privileged = true
+		var testSecurityContext corev1.SecurityContext = corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{
+					"TEST_CONTAINER",
 				},
-				Privileged: &privileged,
-			}
-			BeforeEach(func() {
-				testOption = container.WithSecurityContext(&testSecurityContext)
-				Expect(testContainer.SecurityContext).To(BeNil())
-				testOption(&testContainer) // apply the option
-				*zeroContainer = testContainer
-				zeroContainer.SecurityContext = nil
-			})
-			It("should have SecurityContext with no side effects", func() {
-				Expect(testContainer.SecurityContext).To(Equal(&testSecurityContext))
-				Expect(*zeroContainer).To(BeZero())
-			})
+			},
+			Privileged: &privileged,
+		}
+		BeforeEach(func() {
+			testOption = container.WithSecurityContext(&testSecurityContext)
+			Expect(testContainer.SecurityContext).To(BeNil())
+			testOption(&testContainer) // apply the option
+			*zeroContainer = testContainer
+			zeroContainer.SecurityContext = nil
+		})
+		It("should have SecurityContext with no side effects", func() {
+			Expect(testContainer.SecurityContext).To(Equal(&testSecurityContext))
+			Expect(*zeroContainer).To(BeZero())
 		})
 	})
 })

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -201,6 +201,7 @@ func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job 
 	if plan.Spec.Prepare != nil {
 		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers,
 			upgradectr.New("prepare", *plan.Spec.Prepare,
+				upgradectr.WithLatestTag(plan.Status.LatestVersion),
 				upgradectr.WithSecrets(plan.Spec.Secrets),
 				upgradectr.WithPlanEnvironment(plan.Name, plan.Status),
 				upgradectr.WithImagePullPolicy(ImagePullPolicy),
@@ -253,7 +254,7 @@ func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job 
 	// and finally, we upgrade
 	podTemplate.Spec.Containers = []corev1.Container{
 		upgradectr.New("upgrade", *plan.Spec.Upgrade,
-			upgradectr.WithImageTag(plan.Status.LatestVersion),
+			upgradectr.WithLatestTag(plan.Status.LatestVersion),
 			upgradectr.WithSecurityContext(&corev1.SecurityContext{
 				Privileged: &Privileged,
 				Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
In reviewing #60 I realized that the `WithImageTag` function was buggy as well as the tests for it. So, in the spirit of the changes submitted in #60 (requested in #59) I have replaced it with `WithLatestTag` which will not override a tag if an image reference already has one. Additionally I have used this for the `prepare` container to satisfy #41.

This means that SUC interprets a tag-less image ref specified for `prepare` or `upgrade` containers to have the plan's resolved version (aka `.status.latestVersion`) instead of `latest`. Image refs with tags for `prepare` and/or `upgrade` containers are left as-is.

Fixes #41
Fixes #59