### PR TITLE
support plan tolerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ spec:
   # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: k3os-upgrade
 
+  # Specify which node taints should be tolerated by pods applying the upgrade.
+  # Anything specified here is appended to the default of:
+  # - {key: node.kubernetes.io/unschedulable, effect: NoSchedule, operator: Exists}
+  tolerations:
+  - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: amd64}
+  - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: arm64}
+  - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: arm}
+
   # The prepare init container, if specified, is run before cordon/drain which is run before the upgrade container.
   # Shares the same format as the `upgrade` container.
   prepare:

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/system-upgrade-controller/pkg/condition"
 	"github.com/rancher/wrangler/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,6 +38,8 @@ type PlanSpec struct {
 	Channel string       `json:"channel,omitempty"`
 	Version string       `json:"version,omitempty"`
 	Secrets []SecretSpec `json:"secrets,omitempty"`
+
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	Prepare *ContainerSpec `json:"prepare,omitempty"`
 	Cordon  bool           `json:"cordon,omitempty"`

--- a/pkg/apis/upgrade.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/upgrade.cattle.io/v1/zz_generated_deepcopy.go
@@ -24,6 +24,7 @@ import (
 	time "time"
 
 	genericcondition "github.com/rancher/wrangler/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -163,6 +164,13 @@ func (in *PlanSpec) DeepCopyInto(out *PlanSpec) {
 		in, out := &in.Secrets, &out.Secrets
 		*out = make([]SecretSpec, len(*in))
 		copy(*out, *in)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Prepare != nil {
 		in, out := &in.Prepare, &out.Prepare

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -155,11 +155,11 @@ func New(plan *upgradeapiv1.Plan, nodeName, controllerName string) *batchv1.Job 
 							}},
 						},
 					},
-					Tolerations: []corev1.Toleration{{
+					Tolerations: append([]corev1.Toleration{{
 						Key:      corev1.TaintNodeUnschedulable,
 						Operator: corev1.TolerationOpExists,
 						Effect:   corev1.TaintEffectNoSchedule,
-					}},
+					}}, plan.Spec.Tolerations...),
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes: []corev1.Volume{{
 						Name: `host-root`,


### PR DESCRIPTION
Add `tolerations` to `plan.spec`. These will be appended to the default toleration of `node.kubernetes.io/unschedulable:NoSchedule` for pods that apply this plan.

Fixes #55 