### PR TITLE
build: sidestep kustomize v3.5.5

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -25,7 +25,7 @@ RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0; \
     fi
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3; \
+        GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4; \
     fi
 ARG SONOBUOY_VERSION=0.17.2
 RUN if [ "${ARCH}" != "arm" ]; then \


### PR DESCRIPTION
Because that build done broke. Pinned to 3.5.4 for now.

See https://github.com/kubernetes-sigs/kustomize/issues/2462