### PR TITLE
manifests/system-upgrade-controller.yaml: Added tolerations.

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -59,6 +59,12 @@ spec:
               - matchExpressions:
                   - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
       serviceAccountName: system-upgrade
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
           image: rancher/system-upgrade-controller:v0.5.0


### PR DESCRIPTION
Added tolerations for "CriticalAddonsOnly" and "node-role.kubernetes.io/master".
The Deployment has nodeAffinity to "node-role.kubernetes.io/master", but has no tolerations.
If the master node is tainted, the Pod cannot be scheduled and stays in Pending.