### PR TITLE
upgrade plans + documentation update + fix for rancher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ The most up-to-date manifest is always [manifests/system-upgrade-controller.yaml
 but since release v0.4.0 a manifest specific to the release has been created and uploaded to the release artifacts page.
 See [releases/download/v0.4.0/system-upgrade-controller.yaml](https://github.com/rancher/system-upgrade-controller/releases/download/v0.4.0/system-upgrade-controller.yaml)
 
+Make sure to mark at least one master nodes, or controlplane node with upgrade.cattle.io/controller=system-upgrade-controller:
+
+```shell script
+kubectl label node --selector='node-role.kubernetes.io/master' upgrade.cattle.io/controller=system-upgrade-controller
+# or
+kubectl label node --selector='node-role.kubernetes.io/controlplane' upgrade.cattle.io/controller=system-upgrade-controller
+```
+
 But in the time-honored tradition of `curl ${script} | sudo sh -` here is a nice one-liner:
 
 ```shell script

--- a/examples/upgrades/README.md
+++ b/examples/upgrades/README.md
@@ -1,0 +1,10 @@
+# Rolling OS upgrades
+
+This folder containsthe plans for:
+
+-  Ubuntu 18.04 ([`bionic.yaml`](bionic.yaml)) 
+-  Centos 7 ([`centos7.yaml`](centos7.yaml)). 
+
+These plans will upgrade all parts of the OS, and will do a install of docker after reboot.
+
+The [`upgrade.sh`](upgrade.sh) file will install the plans, label all nodes and force an upgrade of the nodes.

--- a/examples/upgrades/bionic.yaml
+++ b/examples/upgrades/bionic.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bionic
+  namespace: system-upgrade
+type: Opaque
+stringData:
+  upgrade.sh: |
+    #!/bin/sh
+    set -e
+    # mark containerd.io to hold, otherwise it will kill this container BAD!
+    apt-mark hold containerd.io
+    # do actual upgrade
+    apt-get --assume-yes update
+    apt-get --assume-yes dist-upgrade
+    # unmark
+    apt-mark unhold containerd.io
+    # reboot
+    if [ -f /run/reboot-required ]; then
+      cat /run/reboot-required
+      # magic to install docker after the reboot
+      if [ -e /etc/rc.d/rc.local ]; then
+        mv /etc/rc.d/rc.local /etc/rc.d/rc.local.orig
+      fi
+      cp /run/system-upgrade/secrets/bionic/rc.local /etc/rc.d/rc.local
+      chmod 755 /etc/rc.d/rc.local
+      reboot
+    fi
+  rc.local: |
+    #!/bin/bash
+    apt-get upgrade -y containerd.io
+    if [ -e /etc/rc.d/rc.local.orig ]; then
+      /etc/rc.d/rc.local.orig
+      mv /etc/rc.d/rc.local.orig /etc/rc.d/rc.local
+    else
+      rm /etc/rc.d/rc.local
+    fi  
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: bionic-master
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  nodeSelector:
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/bionic, operator: Exists}
+      - {key: node-role.kubernetes.io/master, operator: In, values: ["true"]}
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/bionic, operator: Exists}
+      - {key: node-role.kubernetes.io/controlplane, operator: In, values: ["true"]}
+  tolerations:
+    - key: "node-role.kubernetes.io/controlplane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/etcd"
+      operator: "Exists"
+      effect: "NoExecute"
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: bionic
+      path: /host/run/system-upgrade/secrets/bionic
+  drain:
+    force: true
+  version: bionic
+  upgrade:
+    image: ubuntu
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/bionic/upgrade.sh"]
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: bionic-worker
+  namespace: system-upgrade
+spec:
+  concurrency: 2
+  nodeSelector:
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/bionic, operator: Exists}
+      - {key: node-role.kubernetes.io/master, operator: NotIn, values: ["true"]}
+      - {key: node-role.kubernetes.io/controlplane, operator: NotIn, values: ["true"]}
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: bionic
+      path: /host/run/system-upgrade/secrets/bionic
+  drain:
+    force: true
+  version: bionic
+  upgrade:
+    image: ubuntu
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/bionic/upgrade.sh"]

--- a/examples/upgrades/centos7.yaml
+++ b/examples/upgrades/centos7.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: centos7
+  namespace: system-upgrade
+type: Opaque
+stringData:
+  upgrade.sh: |
+    #!/bin/sh
+    set -e
+    # do actual upgrade
+    setenforce 0
+    yum upgrade -y --exclude docker-ce
+    setenforce 1
+    # needs-restarting returns 1 if reboot is needed
+    if ! needs-restarting -r &> /dev/null; then
+      needs-restarting -r || /bin/true  # otherwise script ends due to -e
+      # magic to install docker after the reboot
+      if [ -e /etc/rc.d/rc.local ]; then
+        mv /etc/rc.d/rc.local /etc/rc.d/rc.local.orig
+      fi
+      cp /run/system-upgrade/secrets/centos7/rc.local /etc/rc.d/rc.local
+      chmod 755 /etc/rc.d/rc.local
+      reboot
+    fi
+  rc.local: |
+    #!/bin/bash
+    yum upgrade -y docker-ce
+    if [ -e /etc/rc.d/rc.local.orig ]; then
+      /etc/rc.d/rc.local.orig
+      mv /etc/rc.d/rc.local.orig /etc/rc.d/rc.local
+    else
+      rm /etc/rc.d/rc.local
+    fi  
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: centos7-master
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  nodeSelector:
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/centos7, operator: Exists}
+      - {key: node-role.kubernetes.io/master, operator: In, values: ["true"]}
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/centos7, operator: Exists}
+      - {key: node-role.kubernetes.io/controlplane, operator: In, values: ["true"]}
+  tolerations:
+    - key: "node-role.kubernetes.io/controlplane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/etcd"
+      operator: "Exists"
+      effect: "NoExecute"
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: centos7
+      path: /host/run/system-upgrade/secrets/centos7
+  drain:
+    force: true
+  version: centos7
+  upgrade:
+    image: centos
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/centos7/upgrade.sh"]
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: centos7-worker
+  namespace: system-upgrade
+spec:
+  concurrency: 2
+  nodeSelector:
+    matchExpressions:
+      - {key: plan.upgrade.cattle.io/centos7, operator: Exists}
+      - {key: node-role.kubernetes.io/master, operator: NotIn, values: ["true"]}
+      - {key: node-role.kubernetes.io/controlplane, operator: NotIn, values: ["true"]}
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: centos7
+      path: /host/run/system-upgrade/secrets/centos7
+  drain:
+    force: true
+  version: centos7
+  upgrade:
+    image: centos
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/centos7/upgrade.sh"]

--- a/examples/upgrades/upgrade.sh
+++ b/examples/upgrades/upgrade.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# load plans
+kubectl apply -f bionic.yaml -f centos.yaml
+
+# label all nodes for centos 7
+kubectl get nodes -o=custom-columns=NAME:.metadata.name,NODE:.status.nodeInfo.osImage | awk '/CentOS Linux 7/ { print $1 }' | xargs -t -I % -n 1 kubectl label node % plan.upgrade.cattle.io/centos7=true 
+# force os upgrade on master and workers
+kubectl label nodes --selector='plan.upgrade.cattle.io/centos7-master' plan.upgrade.cattle.io/centos7-master-
+kubectl label nodes --selector='plan.upgrade.cattle.io/centos7-worker' plan.upgrade.cattle.io/centos7-worker-
+
+# label all nodes for ubuntu 18.04
+kubectl get nodes -o=custom-columns=NAME:.metadata.name,NODE:.status.nodeInfo.osImage | awk '/Ubuntu 18.04/ { print $1 }' | xargs -t -I % -n 1 kubectl label node % plan.upgrade.cattle.io/bionic=true 
+# force os upgrade on master and workers
+kubectl label nodes --selector='plan.upgrade.cattle.io/bionic-master' plan.upgrade.cattle.io/bionic-master-
+kubectl label nodes --selector='plan.upgrade.cattle.io/bionic-worker' plan.upgrade.cattle.io/bionic-worker-
+

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -58,6 +58,8 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+              - matchExpressions:
+                  - {key: "node-role.kubernetes.io/controlplane", operator: In, values: ["true"]}
       serviceAccountName: system-upgrade
       tolerations:
         - key: "CriticalAddonsOnly"
@@ -65,6 +67,12 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/controlplane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/etcd"
+          operator: "Exists"
+          effect: "NoExecute"
       containers:
         - name: system-upgrade-controller
           image: rancher/system-upgrade-controller:v0.5.0


### PR DESCRIPTION
This project solved a major headache for me, how to upgrade the underlying OS and cleanly reboot machines.

When experimenting with this I could not easily find in the documentation why the system-upgrade was not running. I added some text to the README to help new users to add the right label to either the master or controlplane nodes.

The cluster I tried this with is managed by rancher and it does not have nodes marked as master, but either as controlplane or etcd. I modified the system-upgrade-controller.yaml to work with these roles as well as the original master role.

Finally my plans to upgrade both bionic and centos 7 machines. This will make sure that the machine reboots and will install docker if needed