### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ But in the time-honored tradition of `curl ${script} | sudo sh -` here is a nice
 
 ```shell script
 # Y.O.L.O.
-kustomize build https://github.com/rancher/system-upgrade-controller | kubectl apply -f - 
+kustomize build github.com/rancher/system-upgrade-controller | kubectl apply -f - 
 ```
 
 ### Example Plans


### PR DESCRIPTION
Removed protocol from `kustomize` URL for autodetect protocol (https://github.com/hashicorp/go-getter#url-format).

Somehow `Git detector` is not detecting `https://github.com/rancher/system-upgrade-controller` as Github URL:

```
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/private/var/folders/97/y9dd3fls1476xjh1jf3d087h0000gn/T/kustomize-997201582/repo'
```
