### PR TITLE
manifest: mount host's /etc/pki

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -84,6 +84,8 @@ spec:
           volumeMounts:
             - name: etc-ssl
               mountPath: /etc/ssl
+            - name: etc-pki
+              mountPath: /etc/pki
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -91,5 +93,9 @@ spec:
           hostPath:
             path: /etc/ssl
             type: Directory
+        - name: etc-pki
+          hostPath:
+            path: /etc/pki
+            type: DirectoryOrCreate
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
On Fedora-like distributions, /etc/ssl contains only symlinks to CA certificates. Actual certificates are stored in /etc/pki. Without mounting the later, symlinks in /etc/ssl are dangling.
Note: there's no way to detect if /etc/pki directory exists / is needed, thus usage of DirectoryOrCreate. It will cause empty /etc/pki to be created on hosts even on Debian-like distributions.

Fixes https://github.com/rancher/system-upgrade-controller/issues/105