### PR TITLE
FIX: misspelled taint in manifest

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -65,7 +65,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/control-plane"
+        - key: "node-role.kubernetes.io/controlplane"
           operator: "Exists"
           effect: "NoSchedule"
         - key: "node-role.kubernetes.io/etcd"


### PR DESCRIPTION
I think it shoud be `controlplane` instead of `control-plane`.
I've checked my RKE clusters and https://rancher.com/docs/rke/latest/en/config-options/nodes/ , in both cases it's `controlplane`