### PR TITLE
adjust job node affinity to use hostname value

### DIFF
--- a/pkg/upgrade/handle_upgrade.go
+++ b/pkg/upgrade/handle_upgrade.go
@@ -68,15 +68,14 @@ func (ctl *Controller) handlePlans(ctx context.Context) error {
 			if !upgradeapiv1.PlanLatestResolved.IsTrue(obj) {
 				return objects, status, nil
 			}
-			concurrentNodeNames, err := upgradeplan.SelectConcurrentNodeNames(obj, nodes.Cache())
+			concurrentNodes, err := upgradeplan.SelectConcurrentNodes(obj, nodes.Cache())
 			if err != nil {
 				return objects, status, err
 			}
-			logrus.Debugf("concurrentNodeNames = %q", concurrentNodeNames)
-			for _, nodeName := range concurrentNodeNames {
-				objects = append(objects, upgradejob.New(obj, nodeName, ctl.Name))
+			for _, node := range concurrentNodes {
+				objects = append(objects, upgradejob.New(obj, node, ctl.Name))
+				obj.Status.Applying = append(obj.Status.Applying, node.Name)
 			}
-			obj.Status.Applying = concurrentNodeNames
 			return objects, obj.Status, nil
 		},
 		&generic.GeneratingHandlerOptions{

--- a/pkg/upgrade/job/flags_test.go
+++ b/pkg/upgrade/job/flags_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestNew(t *testing.T) {
@@ -20,7 +23,15 @@ func TestNew(t *testing.T) {
 				Spec: upgradeapiv1.PlanSpec{Drain: &upgradeapiv1.DrainSpec{SkipWaitForDeleteTimeout: val},
 					Upgrade: &upgradeapiv1.ContainerSpec{Image: "image"}},
 			})
-			job := New(plan, "node1", "ctr")
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Labels: labels.Set{
+						corev1.LabelHostname: "node1",
+					},
+				},
+			}
+			job := New(plan, node, "ctr")
 			t.Logf("%#v", job.Spec.Template.Spec.InitContainers)
 			for _, container := range job.Spec.Template.Spec.InitContainers {
 				if container.Name == "drain" {


### PR DESCRIPTION
Fix job node affinity for nodes with names that do not match the value
of their `kubernetes.io/hostname` label. With this change, node names
are still reported in the **Plan**'s `.status.applying` slice but jobs are generated
with correct node-affinity via matching on the value of
`kubernetes.io/hostname`.

Fixes #119

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
