### PR TITLE
Mount host /etc/ca-certificates

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -95,6 +95,8 @@ spec:
               mountPath: /etc/ssl
             - name: etc-pki
               mountPath: /etc/pki
+            - name: etc-ca-certificates
+              mountPath: /etc/ca-certificates
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -105,6 +107,10 @@ spec:
         - name: etc-pki
           hostPath:
             path: /etc/pki
+            type: DirectoryOrCreate
+        - name: etc-ca-certificates
+          hostPath:
+            path: /etc/ca-certificates
             type: DirectoryOrCreate
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
OSes like Arch Linux put certificate files in /etc/ca-certificates, and symlink to those files from /etc/ssl and /etc/pki.

This is in the same spirit as #116.