### PR TITLE
fix for duplicate applying nodes

### DIFF
--- a/pkg/upgrade/node/node.go
+++ b/pkg/upgrade/node/node.go
@@ -1,0 +1,12 @@
+package node
+
+import corev1 "k8s.io/api/core/v1"
+
+func Hostname(node *corev1.Node) string {
+	if node.Labels != nil {
+		if hostname, ok := node.Labels[corev1.LabelHostname]; ok {
+			return hostname
+		}
+	}
+	return node.Name
+}


### PR DESCRIPTION
Make duplicate entries for .status.applying on plans magically disappear
by correctly sorting the return value for SelectConcurrentNodes.

Fixes #132

Additionally, address a logic bug introduced in #126 that could also
spin out of control.

See
https://github.com/rancher/system-upgrade-controller/commit/90e3d082a41fefaf09d14286b880c54a28af6c21

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
