### PR TITLE
Relax affinity rules for controller

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -57,7 +57,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+                  - {key: "node-role.kubernetes.io/master", operator: Exists}
       serviceAccountName: system-upgrade
       tolerations:
         - key: "CriticalAddonsOnly"


### PR DESCRIPTION
More recent clusters set an empty value for the node-role labels. This
change makes the SUC work out of the box with those clusters while
retaining backwards compatibility.

Fixes #136