### PR TITLE
[release-0.7] Use short host name in job name

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -3,6 +3,7 @@ package job
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/rancher/system-upgrade-controller/pkg/apis/condition"
 	upgradeapi "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
@@ -94,9 +95,10 @@ var (
 func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *batchv1.Job {
 	hostPathDirectory := corev1.HostPathDirectory
 	labelPlanName := upgradeapi.LabelPlanName(plan.Name)
+	shortNodeName := strings.SplitN(upgradenode.Hostname(node), ".", 2)[0]
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName("apply", plan.Name, "on", node.Name, "with", plan.Status.LatestHash),
+			Name:      name.SafeConcatName("apply", plan.Name, "on", shortNodeName, "with", plan.Status.LatestHash),
 			Namespace: plan.Namespace,
 			Annotations: labels.Set{
 				upgradeapi.AnnotationTTLSecondsAfterFinished: strconv.FormatInt(int64(TTLSecondsAfterFinished), 10),


### PR DESCRIPTION
The Kubernetes job controller unsafely trims the Job name when setting
the GenerateName for the Job Pods, but if we keep the hostname short
we're less likely to trip over it until the bug can be fixed upstream.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>