### PR TITLE
Use plan.Spec.Upgrade in hash

### DIFF
--- a/pkg/apis/upgrade.cattle.io/constants.go
+++ b/pkg/apis/upgrade.cattle.io/constants.go
@@ -6,6 +6,12 @@ const (
 	// AnnotationTTLSecondsAfterFinished is used to store a fallback value for job.spec.ttlSecondsAfterFinished
 	AnnotationTTLSecondsAfterFinished = GroupName + `/ttl-seconds-after-finished`
 
+	// AnnotationIncludeInDigest is used to determine parts of the plan to include in the hash for upgrading
+	// The value should be a comma-delimited string corresponding to the sections of the plan.
+	// For example, a value of "spec.concurrency,spec.upgrade.envs" will include
+	// spec.concurrency and spec.upgrade.envs from the plan in the hash to track for upgrades.
+	AnnotationIncludeInDigest = GroupName + `/digest`
+
 	// LabelController is the name of the upgrade controller.
 	LabelController = GroupName + `/controller`
 


### PR DESCRIPTION
Previously, secrets, image, and service account were used when tracking
updates of a plan with hashing. This made it impossible to trigger an
update by updating something like the environment variables.

After this change, anything in plan.Spec.Upgrade will be used in the
hash to track changes.

Issue:
https://github.com/rancher/rancher/issues/32633
https://github.com/rancher/rancher/issues/34908