### PR TITLE
By default restart pods on failure

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -166,7 +166,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 						Operator: corev1.TolerationOpExists,
 						Effect:   corev1.TaintEffectNoSchedule,
 					}}, plan.Spec.Tolerations...),
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
 					Volumes: []corev1.Volume{{
 						Name: `host-root`,
 						VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Prior to this is a pod failed for any reason we would not recover for
maybe 15 minutes.  By setting the RestartPolicy to OnFailure the jobs
will be more resilient to transient failure.  The big issue we are trying
to address is when the kubelet fails to launch a pod because it
can't find the host-info volume, which is transient.