### PR TITLE
Add default fields in Job

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -178,10 +178,11 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 						Name: "pod-info",
 						VolumeSource: corev1.VolumeSource{
 							DownwardAPI: &corev1.DownwardAPIVolumeSource{
+								DefaultMode: &[]int32{420}[0],
 								Items: []corev1.DownwardAPIVolumeFile{{
-									Path: "labels", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels"},
+									Path: "labels", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels", APIVersion: "v1"},
 								}, {
-									Path: "annotations", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.annotations"},
+									Path: "annotations", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.annotations", APIVersion: "v1"},
 								}},
 							},
 						},


### PR DESCRIPTION
With the new version of wrangler, default fields are added. This poses
an issue when Apply is called again because these default fields won't
exist on the next call. This causes wrangler to think that something has
changed.

In this fix, default fields are added to the Job to prevent this issue.

Related issue:
https://github.com/rancher/rancher/issues/35819