### PR TITLE
Use github-release-s390x image in s390x pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -111,7 +111,7 @@ steps:
 
 - name: upload-artifacts
   failure: ignore
-  image: plugins/github-release
+  image: rancher/drone-images:github-release-s390x
   settings:
     api_key:
       from_secret: github_token


### PR DESCRIPTION
The github-release plugin does not exist for s390x so we need to use an alternative image.