### PR TITLE
Add ownerReferences to Job metadata

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -98,6 +98,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 	labelPlanName := upgradeapi.LabelPlanName(plan.Name)
 	nodeHostname := upgradenode.Hostname(node)
 	shortNodeName := strings.SplitN(nodeHostname, ".", 2)[0]
+	ownerRefController := true
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName("apply", plan.Name, "on", shortNodeName, "with", plan.Status.LatestHash),
@@ -111,6 +112,15 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 				upgradeapi.LabelPlan:       plan.Name,
 				upgradeapi.LabelVersion:    plan.Status.LatestVersion,
 				labelPlanName:              plan.Status.LatestHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: plan.APIVersion,
+					Kind:       plan.Kind,
+					Name:       plan.Name,
+					UID:        plan.UID,
+					Controller: &ownerRefController,
+				},
 			},
 		},
 		Spec: batchv1.JobSpec{


### PR DESCRIPTION
This PR adds the `ownerReferences` field to the jobs, pointing to the corresponding plan that generated them. This allows to link the jobs to the plan and optimize GC, just like between a replicaset and its pods.

This is also useful for visualization in tools like ArgoCD. Without this field, you only get a view of the plan itself without its associated jobs:
![without_ownerref](https://user-images.githubusercontent.com/11899826/213671081-e97269fe-e2ac-4c3b-a9f4-49713f35d8a5.png)

With the field set, we have greater visibility about what's currently happening through the plan and can see the jobs running:
![with_ownerref](https://user-images.githubusercontent.com/11899826/213671643-1142e025-8f8d-4a74-8a21-7c28e7fd0b1f.png)

This could be considered as a breaking change as deletion of the plan implies deletion of the associated jobs, so you can potentially lose some kind of information if you're not careful. Using an optional flag to enable this could be implemented if needed

As for the change itself, I'm far from being a golang warrior so there may be a better way to implement this. The same goes for the go testing framework that I'm definitely not used to ^^, so I don't really know how to implement a test for this change (or maybe there's no need to for such a change).