### PR TITLE
Set Kubernetes owner references on Job objects

### DIFF
--- a/e2e/cluster/local/images/k3s/Dockerfile
+++ b/e2e/cluster/local/images/k3s/Dockerfile
@@ -1,9 +1,9 @@
 # Install the all-in-one binary so we can copy our run-time images into the image
 # which helps avoid pulling them when running e2e tests.
-ARG SLES="registry.suse.com/suse/sle15:15.3"
+ARG SLES="registry.suse.com/suse/sle15:15.4"
 FROM ${SLES} AS k3s
 ARG ARCH
-ARG K3S_VERSION="v1.21.9+k3s1"
+ARG K3S_VERSION="v1.23.17+k3s1"
 RUN set -x \
  && zypper -n in \
     ca-certificates \

--- a/pkg/upgrade/handle_upgrade.go
+++ b/pkg/upgrade/handle_upgrade.go
@@ -97,6 +97,7 @@ func (ctl *Controller) handlePlans(ctx context.Context) error {
 		},
 		&generic.GeneratingHandlerOptions{
 			AllowClusterScoped: true,
+			NoOwnerReference:   true,
 		},
 	)
 

--- a/scripts/e2e-sonobuoy
+++ b/scripts/e2e-sonobuoy
@@ -22,6 +22,7 @@ e2e-sonobuoy-run() {
     --sonobuoy-image=${SONOBUOY_RUN_SONOBUOY_IMAGE} \
     --wait=${SONOBUOY_RUN_WAIT}
   mv -vf $(sonobuoy retrieve) ${DIST}/sonobuoy-results-${ARCH}.tar.gz
+  sonobuoy results --mode=dump ${DIST}/sonobuoy-results-${ARCH}.tar.gz
   sonobuoy results ${DIST}/sonobuoy-results-${ARCH}.tar.gz | tee ${DIST}/../sonobuoy-results-${ARCH}.txt
 }
 export -f e2e-sonobuoy-run


### PR DESCRIPTION
Ensures that owner references are properly set on the generated Job resources, so that they can be tracked by other projects that don't understand how to track relationships using the `objectset.rio.cattle.io/owner-*` annotations (which is pretty much everything).

This is a simpler version of:
* https://github.com/rancher/system-upgrade-controller/pull/220

Linked issue:
* https://github.com/rancher/system-upgrade-controller/issues/236