### PR TITLE
Fix Spec.Drain.PodSelector

### DIFF
--- a/e2e/suite/job_generate_test.go
+++ b/e2e/suite/job_generate_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Job Generation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(jobs).To(HaveLen(1))
 			Expect(jobs[0].Status.Succeeded).To(BeNumerically("==", 0))
+			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically(">=", 1))
 
 			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
@@ -57,6 +58,7 @@ var _ = Describe("Job Generation", func() {
 		It("should apply successfully after edit", func() {
 			Expect(jobs).To(HaveLen(1))
 			Expect(jobs[0].Status.Succeeded).To(BeNumerically("==", 1))
+			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically("==", 0))
 		})
 	})
@@ -112,9 +114,11 @@ var _ = Describe("Job Generation", func() {
 		It("should apply successfully after edit", func() {
 			Expect(jobs).To(HaveLen(1))
 			Expect(jobs[0].Status.Succeeded).To(BeNumerically("==", 1))
+			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically("==", 0))
 			Expect(jobs[0].Spec.Template.Spec.InitContainers).To(HaveLen(1))
-			Expect(jobs[0].Spec.Template.Spec.InitContainers[0].Args).To(ContainSubstring("csi-attacher"))
+			Expect(jobs[0].Spec.Template.Spec.InitContainers[0].Args).To(ContainSubstring("!upgrade.cattle.io/controller"))
+			Expect(jobs[0].Spec.Template.Spec.InitContainers[0].Args).To(ContainSubstring("app notin (csi-attacher,csi-provisioner)"))
 		})
 	})
 })

--- a/pkg/upgrade/plan/plan.go
+++ b/pkg/upgrade/plan/plan.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	ErrDrainDeleteConflict = fmt.Errorf("spec.drain cannot specify both deleteEmptydirData and deleteLocalData")
+	ErrDrainDeleteConflict           = fmt.Errorf("spec.drain cannot specify both deleteEmptydirData and deleteLocalData")
+	ErrDrainPodSelectorNotSelectable = fmt.Errorf("spec.drain.podSelector is not selectable")
 
 	PollingInterval = func(defaultValue time.Duration) time.Duration {
 		if str, ok := os.LookupEnv("SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL"); ok {
@@ -236,6 +237,15 @@ func Validate(plan *upgradeapiv1.Plan) error {
 	if drainSpec := plan.Spec.Drain; drainSpec != nil {
 		if drainSpec.DeleteEmptydirData != nil && drainSpec.DeleteLocalData != nil {
 			return ErrDrainDeleteConflict
+		}
+		if drainSpec.PodSelector != nil {
+			selector, err := metav1.LabelSelectorAsSelector(drainSpec.PodSelector)
+			if err != nil {
+				return err
+			}
+			if _, ok := selector.Requirements(); !ok {
+				return ErrDrainPodSelectorNotSelectable
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Use helpers instead of string ops to handle pod selector generation.

The previous logic was generating invalid LabelSelector strings, and the e2e test didn't catch it because it was just looking for a substring, not the full LabelSelector value.