### PR TITLE
feat: allow plan to ignore secret updates

### DIFF
--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -88,6 +88,7 @@ type DrainSpec struct {
 
 // SecretSpec describes a secret to be mounted for prepare/upgrade containers.
 type SecretSpec struct {
-	Name string `json:"name,omitempty"`
-	Path string `json:"path,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Path          string `json:"path,omitempty"`
+	IgnoreUpdates bool   `json:"ignoreUpdates,omitempty"`
 }

--- a/pkg/upgrade/handle_core.go
+++ b/pkg/upgrade/handle_core.go
@@ -48,8 +48,10 @@ func (ctl *Controller) handleSecrets(ctx context.Context) error {
 		for _, plan := range planList {
 			for _, secret := range plan.Spec.Secrets {
 				if obj.Name == secret.Name {
-					plans.Enqueue(plan.Namespace, plan.Name)
-					continue
+					if !secret.IgnoreUpdates {
+						plans.Enqueue(plan.Namespace, plan.Name)
+						continue
+					}
 				}
 			}
 		}

--- a/pkg/upgrade/plan/plan.go
+++ b/pkg/upgrade/plan/plan.go
@@ -79,11 +79,13 @@ func DigestStatus(plan *upgradeapiv1.Plan, secretCache corectlv1.SecretCache) (u
 			if err != nil {
 				return plan.Status, err
 			}
-			secretHash, err := hash.SecretHash(secret)
-			if err != nil {
-				return plan.Status, err
+			if !s.IgnoreUpdates {
+				secretHash, err := hash.SecretHash(secret)
+				if err != nil {
+					return plan.Status, err
+				}
+				h.Write([]byte(secretHash))
 			}
-			h.Write([]byte(secretHash))
 		}
 		plan.Status.LatestHash = fmt.Sprintf("%x", h.Sum(nil))
 	}


### PR DESCRIPTION
add spec.secret[].ignoreUpdates to allow the definition of a secret and not trigger an update when that secret is altered

closes #245