### PR TITLE
225: Add support for exclusive plans

### DIFF
--- a/pkg/apis/upgrade.cattle.io/constants.go
+++ b/pkg/apis/upgrade.cattle.io/constants.go
@@ -15,7 +15,7 @@ const (
 	// LabelController is the name of the upgrade controller.
 	LabelController = GroupName + `/controller`
 
-	// LabelExclusive is the value of the Exclusive flag.
+	// LabelExclusive is set if the plan should not run concurrent with other plans.
 	LabelExclusive = GroupName + `/exclusive`
 
 	// LabelNode is the node being upgraded.

--- a/pkg/apis/upgrade.cattle.io/constants.go
+++ b/pkg/apis/upgrade.cattle.io/constants.go
@@ -15,6 +15,9 @@ const (
 	// LabelController is the name of the upgrade controller.
 	LabelController = GroupName + `/controller`
 
+	// LabelExclusive is the value of the Exclusive flag.
+	LabelExclusive = GroupName + `/exclusive`
+
 	// LabelNode is the node being upgraded.
 	LabelNode = GroupName + `/node`
 

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -44,6 +44,8 @@ type PlanSpec struct {
 
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	OnePlanPerNode bool `json:"onePlanPerNode,omitempty"`
+
 	Prepare *ContainerSpec `json:"prepare,omitempty"`
 	Cordon  bool           `json:"cordon,omitempty"`
 	Drain   *DrainSpec     `json:"drain,omitempty"`

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -44,7 +44,7 @@ type PlanSpec struct {
 
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
-	OnePlanPerNode bool `json:"onePlanPerNode,omitempty"`
+	Exclusive bool `json:"exclusive,omitempty"`
 
 	Prepare *ContainerSpec `json:"prepare,omitempty"`
 	Cordon  bool           `json:"cordon,omitempty"`

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -106,6 +106,7 @@ var (
 )
 
 func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *batchv1.Job {
+	exclusiveString := strconv.FormatBool(plan.Spec.Exclusive)
 	hostPathDirectory := corev1.HostPathDirectory
 	labelPlanName := upgradeapi.LabelPlanName(plan.Name)
 	nodeHostname := upgradenode.Hostname(node)
@@ -119,6 +120,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 			},
 			Labels: labels.Set{
 				upgradeapi.LabelController: controllerName,
+				upgradeapi.LabelExclusive:  exclusiveString,
 				upgradeapi.LabelNode:       node.Name,
 				upgradeapi.LabelPlan:       plan.Name,
 				upgradeapi.LabelVersion:    plan.Status.LatestVersion,
@@ -132,6 +134,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels.Set{
 						upgradeapi.LabelController: controllerName,
+						upgradeapi.LabelExclusive:  exclusiveString,
 						upgradeapi.LabelNode:       node.Name,
 						upgradeapi.LabelPlan:       plan.Name,
 						upgradeapi.LabelVersion:    plan.Status.LatestVersion,
@@ -211,14 +214,14 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 		*job.Spec.Parallelism = 1
 	}
 
-	if plan.Spec.OnePlanPerNode {
+	if plan.Spec.Exclusive {
 		job.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{{
 			LabelSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
-					Key:      upgradeapi.LabelNode,
+					Key:      upgradeapi.LabelExclusive,
 					Operator: metav1.LabelSelectorOpIn,
 					Values: []string{
-						node.Name,
+						exclusiveString,
 					},
 				}},
 			},


### PR DESCRIPTION
Add new field to Plan spec, Exclusive. This field will be useful when the order of execution for a series of Jobs is important, as each exclusive Job will have to complete before the next one is scheduled.

Setting the field to true will change the default behavior of how Job Pods are scheduled: it will create a PodAntiAffinity rule which will prevent more than one `exclusive` labeled SUC Job Pod from being scheduled to a node at a time, and will add this label to the Job Pod. 

If omitted or explicitly set to false, Job Pods will be scheduled according to current default behavior. 

Implements request in #225.

@dweomer 