### PR TITLE
feat: allow plan to ignore secret updates

### DIFF
--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -122,6 +122,14 @@ func (c *Client) DeletePlans(options metav1.DeleteOptions, listOpts metav1.ListO
 	return c.UpgradeClientSet.UpgradeV1().Plans(c.Namespace.Name).DeleteCollection(context.TODO(), options, listOpts)
 }
 
+func (c *Client) CreateSecret(secret *corev1.Secret) (*corev1.Secret, error) {
+	return c.ClientSet.CoreV1().Secrets(c.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{})
+}
+
+func (c *Client) UpdateSecret(secret *corev1.Secret) (*corev1.Secret, error) {
+	return c.ClientSet.CoreV1().Secrets(c.Namespace.Name).Update(context.TODO(), secret, metav1.UpdateOptions{})
+}
+
 func (c *Client) WaitForPlanCondition(name string, cond condition.Cond, timeout time.Duration) (plan *upgradeapiv1.Plan, err error) {
 	return plan, wait.Poll(time.Second, timeout, func() (bool, error) {
 		plan, err = c.GetPlan(name, metav1.GetOptions{})

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -89,6 +89,7 @@ type DrainSpec struct {
 
 // SecretSpec describes a secret to be mounted for prepare/upgrade containers.
 type SecretSpec struct {
-	Name string `json:"name,omitempty"`
-	Path string `json:"path,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Path          string `json:"path,omitempty"`
+	IgnoreUpdates bool   `json:"ignoreUpdates,omitempty"`
 }

--- a/pkg/upgrade/handle_core.go
+++ b/pkg/upgrade/handle_core.go
@@ -48,8 +48,10 @@ func (ctl *Controller) handleSecrets(ctx context.Context) error {
 		for _, plan := range planList {
 			for _, secret := range plan.Spec.Secrets {
 				if obj.Name == secret.Name {
-					plans.Enqueue(plan.Namespace, plan.Name)
-					continue
+					if !secret.IgnoreUpdates {
+						plans.Enqueue(plan.Namespace, plan.Name)
+						continue
+					}
 				}
 			}
 		}

--- a/pkg/upgrade/plan/plan.go
+++ b/pkg/upgrade/plan/plan.go
@@ -79,11 +79,13 @@ func DigestStatus(plan *upgradeapiv1.Plan, secretCache corectlv1.SecretCache) (u
 			if err != nil {
 				return plan.Status, err
 			}
-			secretHash, err := hash.SecretHash(secret)
-			if err != nil {
-				return plan.Status, err
+			if !s.IgnoreUpdates {
+				secretHash, err := hash.SecretHash(secret)
+				if err != nil {
+					return plan.Status, err
+				}
+				h.Write([]byte(secretHash))
 			}
-			h.Write([]byte(secretHash))
 		}
 		plan.Status.LatestHash = fmt.Sprintf("%x", h.Sum(nil))
 	}


### PR DESCRIPTION
add spec.secret[].ignoreUpdates to allow the definition of a secret and not trigger an update when that secret is altered

closes https://github.com/rancher/system-upgrade-controller/issues/245

duplicate of #246 but with the e2e test