### PR TITLE
Use node name for job name instead of host name

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -110,7 +110,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 	hostPathDirectory := corev1.HostPathDirectory
 	labelPlanName := upgradeapi.LabelPlanName(plan.Name)
 	nodeHostname := upgradenode.Hostname(node)
-	shortNodeName := strings.SplitN(nodeHostname, ".", 2)[0]
+	shortNodeName := strings.SplitN(node.Name, ".", 2)[0]
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName("apply", plan.Name, "on", shortNodeName, "with", plan.Status.LatestHash),


### PR DESCRIPTION
Hostnames are not guaranteed safe for use in resource names; thats why the hostname has a separate field on the node object.

* For https://github.com/rancher/system-upgrade-controller/issues/273