### PR TITLE
Propagate labels and annotations from plans to jobs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,77 +90,6 @@ volumes:
 
 ---
 kind: pipeline
-name: s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-- name: build
-  image: rancher/dapper:v0.6.0
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: upload-artifacts
-  image: rancher/drone-images:github-release-s390x
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-s390x.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: push-controller
-  image: rancher/drone-images:docker-s390x
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  settings:
-    dockerfile: package/Dockerfile
-    build_args:
-    - ARCH=s390x
-    - TAG=${DRONE_TAG}-s390x
-    password:
-      from_secret: docker_password
-    repo: "rancher/system-upgrade-controller"
-    tag: "${DRONE_TAG}-s390x"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
 name: arm64
 
 platform:
@@ -266,7 +195,6 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/s390x
     target: "rancher/system-upgrade-controller:${DRONE_TAG}"
     template: "rancher/system-upgrade-controller:${DRONE_TAG}-ARCH"
   when:
@@ -301,7 +229,6 @@ steps:
 
 depends_on:
 - amd64
-- s390x
 - arm64
 
 ---

--- a/pkg/upgrade/job/job_suite_test.go
+++ b/pkg/upgrade/job/job_suite_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Jobs", func() {
 		})
 
 		Context("When the Plan has annotations and labels", func() {
-			It("Copes the non-cattle.io metadata to the Job and Pod", func() {
+			It("Copies the non-cattle.io metadata to the Job and Pod", func() {
 				plan.Annotations = make(map[string]string)
 				plan.Annotations["cattle.io/some-annotation"] = "foo"
 				plan.Annotations["plan.cattle.io/some-annotation"] = "bar"

--- a/pkg/upgrade/job/job_suite_test.go
+++ b/pkg/upgrade/job/job_suite_test.go
@@ -87,5 +87,33 @@ var _ = Describe("Jobs", func() {
 				Expect(*job.Spec.ActiveDeadlineSeconds).To(Equal(int64(300)))
 			})
 		})
+
+		Context("When the Plan has annotations and labels", func() {
+			It("Copes the non-cattle.io metadata to the Job and Pod", func() {
+				plan.Annotations = make(map[string]string)
+				plan.Annotations["cattle.io/some-annotation"] = "foo"
+				plan.Annotations["plan.cattle.io/some-annotation"] = "bar"
+				plan.Annotations["some.other/annotation"] = "baz"
+				plan.Labels = make(map[string]string)
+				plan.Labels["cattle.io/some-label"] = "biz"
+				plan.Labels["plan.cattle.io/some-label"] = "buz"
+				plan.Labels["some.other/label"] = "bla"
+
+				job := sucjob.New(plan, node, "foobar")
+				Expect(job.Annotations).To(Not(HaveKey("cattle.io/some-annotation")))
+				Expect(job.Annotations).To(Not(HaveKey("plan.cattle.io/some-annotation")))
+				Expect(job.Annotations).To(HaveKeyWithValue("some.other/annotation", "baz"))
+				Expect(job.Labels).To(Not(HaveKey("cattle.io/some-label")))
+				Expect(job.Labels).To(Not(HaveKey("plan.cattle.io/some-label")))
+				Expect(job.Labels).To(HaveKeyWithValue("some.other/label", "bla"))
+
+				Expect(job.Spec.Template.Annotations).To(Not(HaveKey("cattle.io/some-annotation")))
+				Expect(job.Spec.Template.Annotations).To(Not(HaveKey("plan.cattle.io/some-annotation")))
+				Expect(job.Spec.Template.Annotations).To(HaveKeyWithValue("some.other/annotation", "baz"))
+				Expect(job.Spec.Template.Labels).To(Not(HaveKey("cattle.io/some-label")))
+				Expect(job.Spec.Template.Labels).To(Not(HaveKey("plan.cattle.io/some-label")))
+				Expect(job.Spec.Template.Labels).To(HaveKeyWithValue("some.other/label", "bla"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
The `cattle.io` filtering seems a bit sketchy - is there a better way to do that?

Closes #160 