### PR TITLE
feat: Reduce permissions for system-upgrade-controller serviceaccount

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- manifests/clusterrole.yaml
+- manifests/clusterrolebinding.yaml
 - manifests/system-upgrade-controller.yaml
 images:
 - name: rancher/system-upgrade-controller

--- a/manifests/clusterrole.yaml
+++ b/manifests/clusterrole.yaml
@@ -1,0 +1,108 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+- apiGroups:
+  - upgrade.cattle.io
+  resources:
+  - plans
+  - plans/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-upgrade-controller
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Borrowed from https://stackoverflow.com/a/63553032
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-drainer
+rules:
+  # Needed to evict pods
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/eviction"
+    verbs:
+      - "create"
+  # Needed to list pods by Node
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "list"
+  # Needed to cordon Nodes
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "patch"
+  # Needed to determine Pod owners
+  - apiGroups:
+      - "apps"
+    resources:
+      - "statefulsets"
+      - "daemonsets"
+      - "replicasets"
+    verbs:
+      - "get"
+      - "list"

--- a/manifests/clusterrolebinding.yaml
+++ b/manifests/clusterrolebinding.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade-drainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-drainer
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: system-upgrade

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -11,19 +11,6 @@ metadata:
   name: system-upgrade
   namespace: system-upgrade
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name:  system-upgrade
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: system-upgrade
-  namespace: system-upgrade
----
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
This patch drastically cuts down the permissions of the system-upgrades-controller from the previous cluster-admin permissions to a tailored set of permissions for the controller.