### PR TITLE
Add a Complete condition to plans

### DIFF
--- a/e2e/suite/job_generate_test.go
+++ b/e2e/suite/job_generate_test.go
@@ -56,6 +56,8 @@ var _ = Describe("Job Generation", func() {
 				WithTimeout(30 * time.Second).
 				Should(WithTransform(upgradeapiv1.PlanComplete.IsTrue, BeFalse()))
 
+			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			plan.Spec.Upgrade.Args = []string{"exit 0"}
 			plan, err = e2e.UpdatePlan(plan)
 			Expect(err).ToNot(HaveOccurred())

--- a/e2e/suite/job_generate_test.go
+++ b/e2e/suite/job_generate_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Job Generation", func() {
 
 			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			Expect(upgradeapiv1.PlanComplete.IsTrue(plan)).To(BeFalse())
 
 			plan.Spec.Upgrade.Args = []string{"exit 0"}
 			plan, err = e2e.UpdatePlan(plan)
@@ -67,6 +68,10 @@ var _ = Describe("Job Generation", func() {
 			Expect(jobs[0].Status.Succeeded).To(BeNumerically("==", 1))
 			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically("==", 0))
+
+			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(upgradeapiv1.PlanComplete.IsTrue(plan)).To(BeTrue())
 		})
 	})
 

--- a/e2e/suite/job_generate_test.go
+++ b/e2e/suite/job_generate_test.go
@@ -51,9 +51,10 @@ var _ = Describe("Job Generation", func() {
 			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically(">=", 1))
 
-			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(upgradeapiv1.PlanComplete.IsTrue(plan)).To(BeFalse())
+			Eventually(e2e.GetPlan).
+				WithArguments(plan.Name, metav1.GetOptions{}).
+				WithTimeout(30 * time.Second).
+				Should(WithTransform(upgradeapiv1.PlanComplete.IsTrue, BeFalse()))
 
 			plan.Spec.Upgrade.Args = []string{"exit 0"}
 			plan, err = e2e.UpdatePlan(plan)
@@ -69,9 +70,10 @@ var _ = Describe("Job Generation", func() {
 			Expect(jobs[0].Status.Active).To(BeNumerically("==", 0))
 			Expect(jobs[0].Status.Failed).To(BeNumerically("==", 0))
 
-			plan, err = e2e.GetPlan(plan.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(upgradeapiv1.PlanComplete.IsTrue(plan)).To(BeTrue())
+			Eventually(e2e.GetPlan).
+				WithArguments(plan.Name, metav1.GetOptions{}).
+				WithTimeout(30 * time.Second).
+				Should(WithTransform(upgradeapiv1.PlanComplete.IsTrue, BeTrue()))
 		})
 	})
 

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -17,6 +17,8 @@ var (
 	PlanLatestResolved = condition.Cond("LatestResolved")
 	// PlanSpecValidated indicates that the plan spec has been validated.
 	PlanSpecValidated = condition.Cond("Validated")
+	// Complete indicates that the latest version of the plan has completed on all selected nodes.
+	PlanComplete = condition.Cond("Complete")
 )
 
 // +genclient

--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -17,7 +17,7 @@ var (
 	PlanLatestResolved = condition.Cond("LatestResolved")
 	// PlanSpecValidated indicates that the plan spec has been validated.
 	PlanSpecValidated = condition.Cond("Validated")
-	// Complete indicates that the latest version of the plan has completed on all selected nodes.
+	// PlanComplete indicates that the latest version of the plan has completed on all selected nodes.
 	PlanComplete = condition.Cond("Complete")
 )
 

--- a/pkg/upgrade/handle_upgrade.go
+++ b/pkg/upgrade/handle_upgrade.go
@@ -93,8 +93,7 @@ func (ctl *Controller) handlePlans(ctx context.Context) error {
 				concurrentNodeNames[i] = upgradenode.Hostname(node)
 			}
 			obj.Status.Applying = concurrentNodeNames[:]
-			isComplete := len(concurrentNodeNames) == 0 && obj.Spec.Concurrency > 0
-			upgradeapiv1.PlanComplete.SetStatusBool(obj, isComplete)
+			upgradeapiv1.PlanComplete.SetStatusBool(obj, len(concurrentNodeNames) == 0)
 			return objects, obj.Status, nil
 		},
 		&generic.GeneratingHandlerOptions{

--- a/pkg/upgrade/handle_upgrade.go
+++ b/pkg/upgrade/handle_upgrade.go
@@ -93,6 +93,8 @@ func (ctl *Controller) handlePlans(ctx context.Context) error {
 				concurrentNodeNames[i] = upgradenode.Hostname(node)
 			}
 			obj.Status.Applying = concurrentNodeNames[:]
+			isComplete := len(concurrentNodeNames) == 0 && obj.Spec.Concurrency > 0
+			upgradeapiv1.PlanComplete.SetStatusBool(obj, isComplete)
 			return objects, obj.Status, nil
 		},
 		&generic.GeneratingHandlerOptions{


### PR DESCRIPTION
It doesn't feel great to be updating the condition in the generating handler instead of the status handler, but this ensures the condition is in sync with the actual state of the plan.

I poked around a bit in the ETE test infrastructure but wasn't totally sure how to add a test for this.

Closes #291 