### PR TITLE
fix: Add missing namespace references in rendered output

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: system-upgrade
 resources:
 - manifests/clusterrole.yaml
 - manifests/clusterrolebinding.yaml


### PR DESCRIPTION
One could also consider to hardcode the namespace in the manifest files directly, however, using kustomize reduces the overhead for future adjustments.

Fixes #294 