### PR TITLE
fix: Drop unneeded reorder surpression

### DIFF
--- a/scripts/package-controller
+++ b/scripts/package-controller
@@ -34,6 +34,6 @@ if [ "$ARCH" = "amd64" ]; then
   cp kustomization.yaml /tmp/
   trap reset-kustomization EXIT
   kustomize edit set image "rancher/system-upgrade-controller=${REPO}/system-upgrade-controller:${VERSION}"
-  kustomize build --reorder=none --output ./dist/artifacts/system-upgrade-controller.yaml
+  kustomize build --output ./dist/artifacts/system-upgrade-controller.yaml
   go run hack/crdgen.go > ./dist/artifacts/crd.yaml
 fi


### PR DESCRIPTION
This patch drops the deprecated flag for output reordering. This causes the output to be ordered properly instead of following the order of the resource list.

References:
https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/sortoptions/#legacy-sorting