### PR TITLE
Update/fix README kustomize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ But in the time-honored tradition of `curl ${script} | sudo sh -` here is a nice
 
 ```shell script
 # Y.O.L.O.
-kustomize build github.com/rancher/system-upgrade-controller | kubectl apply -f - 
+kubectl apply -k github.com/rancher/system-upgrade-controller
 ```
 
 ### Example Plans

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,6 +5,3 @@ resources:
 - manifests/clusterrole.yaml
 - manifests/clusterrolebinding.yaml
 - manifests/system-upgrade-controller.yaml
-images:
-- name: rancher/system-upgrade-controller
-  newTag: v0.8.0

--- a/manifests/clusterrole.yaml
+++ b/manifests/clusterrole.yaml
@@ -12,6 +12,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -66,7 +66,7 @@ spec:
           effect: "NoExecute"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.11.0
+          image: rancher/system-upgrade-controller:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
Before this patch always version v0.8.0 would be deployed when using the
kustomize command from the README. This patch adjust the kustomization
to not overwrite the version.

The build process is unaffected from this, since during the build script
the kustomize file is adjusted to adjust the version to the current
release. This means the build manifests for release will still have a
pinned version like before.

Reference:
https://github.com/rancher/system-upgrade-controller/blob/4eacc2dabbde943ee59dc7819ea0a04909b05b0f/scripts/package-controller#L36