### PR TITLE
Revert "fix(kustomize): Deploy latest system-upgrade-controller"

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
 - manifests/clusterrole.yaml
 - manifests/clusterrolebinding.yaml
 - manifests/system-upgrade-controller.yaml
+images:
+- name: rancher/system-upgrade-controller
+  newTag: v0.8.0

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 - manifests/system-upgrade-controller.yaml
 images:
 - name: rancher/system-upgrade-controller
-  newTag: v0.8.0
+  newTag: v0.14.0

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -66,7 +66,7 @@ spec:
           effect: "NoExecute"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.11.0
+          image: rancher/system-upgrade-controller:v0.14.0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -66,7 +66,7 @@ spec:
           effect: "NoExecute"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:latest
+          image: rancher/system-upgrade-controller:v0.11.0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This reverts commit [4e31e5d6a0926df9f370a06c9ea3250ee1e088b1](https://github.com/rancher/system-upgrade-controller/commit/4e31e5d6a0926df9f370a06c9ea3250ee1e088b1).

This "fixes" issue #302 by reverting the commit that caused the issue.
Currently some installations break because of the missing `latest` tag on the [docker hub](https://hub.docker.com/r/rancher/system-upgrade-controller/tags) as explained by @brandond [here](https://github.com/rancher/system-upgrade-controller/commit/4e31e5d6a0926df9f370a06c9ea3250ee1e088b1#r139564543)

I suggest reverting this PR once a 'latest' tag has been added to the docker hub but for now keep installations working by using a version tag instead of a latest tag.