### PR TITLE
ci(drone): Add push step for latest manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -205,6 +205,26 @@ steps:
     - refs/tags/*
     event:
     - tag
+- name: controller-latest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    target: "rancher/system-upgrade-controller:latest"
+    template: "rancher/system-upgrade-controller:${DRONE_TAG}-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
 
 - name: e2e-tests
   image: plugins/manifest


### PR DESCRIPTION
This patch adds a push step for a latest image. Various CI steps actually build a latest image but it's never pushed. This patch adds a step in the release pipeline to also push the release as latest to Docker Hub.

This should resolve issues people experience when using plain manifests from the repository which still references a latest image, which currently doesn't exist.

Please not: I have no insight into the CI process here, so let me know if this is not working for some reason.

References:
https://github.com/rancher/system-upgrade-controller/issues/302