### PR TITLE
fix imagePullPolicy

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -67,7 +67,7 @@ spec:
       containers:
         - name: system-upgrade-controller
           image: rancher/system-upgrade-controller:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534


### PR DESCRIPTION
If imagePullPolicy is set to IfNotPresent and the tag is :latest, you get very unintuitive behavior where Kubernetes will not actually get new versions. This kind of behavior is exactly why it's bad practice to use that tag.

Source: https://kubernetes.io/docs/concepts/containers/images/#updating-images