### PR TITLE
fix: system-upgrade-controller-drainer: add missing delete permission for pods in clusterrole

### DIFF
--- a/manifests/clusterrole.yaml
+++ b/manifests/clusterrole.yaml
@@ -91,7 +91,7 @@ rules:
       - "pods/eviction"
     verbs:
       - "create"
-  # Needed to list pods by Node
+  # Needed to list/delete pods by Node
   - apiGroups:
       - ""
     resources:
@@ -99,6 +99,7 @@ rules:
     verbs:
       - "get"
       - "list"
+      - "delete"
   # Needed to cordon Nodes
   - apiGroups:
       - ""


### PR DESCRIPTION
fix: system-upgrade-controller-drainer: add missing delete permission for pods in clusterrole

Fixes #319 

