### PR TITLE
Fix GHA release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,8 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub release
-        run: gh release create "${{ env.TAG }}" --prerelease --title "${{ env.TAG }}" dist/artifacts/*
+        run: gh release create "${{ env.TAG }}" --prerelease --title "${{ env.TAG }}" dist/artifacts/* ||
+             gh release upload "${{ env.TAG }}" --clobber dist/artifacts/*
 
   # Builds Docker images using artifacts from the `build-test` job and pushes 
   # them to DockerHub.
@@ -221,4 +222,4 @@ jobs:
       
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}          
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,26 +97,9 @@ jobs:
     permissions:
       contents: read
       id-token: write # needed for the Vault authentication
-    strategy:
-      matrix:
-        os: [linux]
-        arch: [amd64, arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: latest=false
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value={{ tag }}-${{ matrix.arch }}
 
       - name: Fix the not-a-git-repository issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -124,17 +107,17 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Load Secrets from Vault
+      - name: Read secrets
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
-      - name: Login to DockerHub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
@@ -147,79 +130,11 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
-      - name: Build and push controller image to DockerHub
-        uses: docker/build-push-action@v5
-        id: build
+      - name: Build container image
+        uses: docker/build-push-action@v6
         with:
           context: .
-          file: package/Dockerfile
-          target: controller
-          build-args: |
-            ARCH=${{ matrix.arch }}
           push: true
-          tags: "${{ steps.meta.outputs.tags }}"
-          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
-          labels: "${{ steps.meta.outputs.labels }}"
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: "digests-${{ matrix.os }}-${{ matrix.arch }}"
-          path: /tmp/digests/*
-          if-no-files-found: error
-          overwrite: true
-
-  # Creates a manifest for the images built in the `build-push-images` job
-  # and pushes it to DockerHub.
-  build-push-manifest:
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-images
-    permissions:
-      id-token: write # needed for the Vault authentication
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: latest=false
-
-      - name: Load Secrets from Vault
-        uses: rancher-eio/read-vault-secrets@main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-      
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-      
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)          
-      
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          tags: rancher/system-upgrade-controller:${{ github.event.release.tag_name }}
+          file: package/Dockerfile
+          platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
* Fixes issue where releases would be left without assets if the tag was created by the GH release UI, as the release would already exist.
* Fixes issue where arm64 image is overwriting the amd64 image