### PR TITLE
Fix artifact permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,9 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
+      - name: Fix artifact permissions
+        run: chmod 0755 dist/artifacts/system-upgrade-controller-*
+
       - name: Build container image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Passing the binary artifacts through the GH artifact zip files strips their permissions; we need to make them executable before building the final image.