### PR TITLE
Add support for setting secret mount mode

### DIFF
--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -81,6 +81,7 @@ type VolumeSpec struct {
 	Name        string `json:"name,omitempty"`
 	Source      string `json:"source,omitempty"`
 	Destination string `json:"destination,omitempty"`
+	DefaultMode *int32 `json:"defaultMode,omitempty"`
 }
 
 // DrainSpec encapsulates `kubectl drain` parameters minus node/pod selectors.
@@ -101,6 +102,7 @@ type SecretSpec struct {
 	Name          string `json:"name,omitempty"`
 	Path          string `json:"path,omitempty"`
 	IgnoreUpdates bool   `json:"ignoreUpdates,omitempty"`
+	DefaultMode   *int32 `json:"defaultMode,omitempty"`
 }
 
 // TimeWindowSpec describes a time window in which a Plan should be processed.

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -287,7 +287,8 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 			Name: name.SafeConcatName("secret", secret.Name),
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secret.Name,
+					SecretName:  secret.Name,
+					DefaultMode: secret.DefaultMode,
 				},
 			},
 		})


### PR DESCRIPTION
This will allow setting `defaultMode` on secret mounts. This should be backwards compatible with existing resources.