### PR TITLE
Include tz files in Docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,6 @@
 ARG BCI=registry.suse.com/bci/bci-base:15.6
 ARG GOLANG=registry.suse.com/bci/golang:1.23
+ARG ALPINE=alpine:3.21
 
 FROM ${GOLANG} AS e2e-ginkgo
 ENV GOBIN=/bin
@@ -19,8 +20,12 @@ RUN set -x \
     && zypper -n in tar gzip
 ENTRYPOINT ["/run.sh"]
 
+FROM ${ALPINE} AS zoneinfo
+RUN apk add -U tzdata
+
 FROM scratch AS controller
 ARG TARGETARCH
 COPY dist/artifacts/system-upgrade-controller-${TARGETARCH} /bin/system-upgrade-controller
+COPY --from=zoneinfo /usr/share/zoneinfo /usr/share/zoneinfo
 USER 65534:65534
 ENTRYPOINT ["/bin/system-upgrade-controller"]

--- a/pkg/upgrade/plan/plan.go
+++ b/pkg/upgrade/plan/plan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/crd"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	corectlv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/rancher/wrangler/v3/pkg/schemas/openapi"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -255,7 +256,7 @@ func Validate(plan *upgradeapiv1.Plan) error {
 	}
 	if windowSpec := plan.Spec.Window; windowSpec != nil {
 		if _, err := timewindow.New(windowSpec.Days, windowSpec.StartTime, windowSpec.EndTime, windowSpec.TimeZone); err != nil {
-			return ErrInvalidWindow
+			return merr.NewErrors(ErrInvalidWindow, err)
 		}
 	}
 	if delay := plan.Spec.PostCompleteDelay; delay != nil && delay.Duration < 0 {


### PR DESCRIPTION
Add timezone files to Docker image so that tz names work in spec.window.timeZone. 

These worked in test because tests run in a BCI image, but the shipping docker image is `FROM scratch` and was missing the files. 

We have to use Alpine as the source for zoneinfo, as BCI does not provide 32bit arm images.

Issue:
* https://github.com/rancher/system-upgrade-controller/issues/342