### PR TITLE
Make IgnoreUpdate secrets optional

### DIFF
--- a/pkg/upgrade/handle_upgrade.go
+++ b/pkg/upgrade/handle_upgrade.go
@@ -40,7 +40,7 @@ func (ctl *Controller) handlePlans(ctx context.Context) error {
 			// validate plan, and generate events for transitions
 			validated := upgradeapiv1.PlanSpecValidated
 			validated.CreateUnknownIfNotExists(obj)
-			if err := upgradeplan.Validate(obj); err != nil {
+			if err := upgradeplan.Validate(obj, secretsCache); err != nil {
 				if !validated.IsFalse(obj) {
 					recorder.Eventf(obj, corev1.EventTypeWarning, "ValidateFailed", "Failed to validate plan: %v", err)
 				}

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -288,6 +288,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: secret.Name,
+					Optional:   pointer.Bool(secret.IgnoreUpdates),
 				},
 			},
 		})


### PR DESCRIPTION
Fixes issue where nonexistent secret with ignoreUpdate set would cause the plan to endlessly requeue due to errors. If it is ignored for purposes of plan hash, it should be optional.

* https://github.com/rancher/system-upgrade-controller/issues/346