### PR TITLE
Add support for setting secret mount mode

### DIFF
--- a/pkg/apis/upgrade.cattle.io/v1/types.go
+++ b/pkg/apis/upgrade.cattle.io/v1/types.go
@@ -158,6 +158,9 @@ type SecretSpec struct {
 	Path string `json:"path"`
 	// If set to true, the Secret contents will not be hashed, and changes to the Secret will not trigger new application of the Plan.
 	IgnoreUpdates bool `json:"ignoreUpdates,omitempty"`
+	// Mode to mount the Secret volume with.
+	// +kubebuilder:validation:Optional
+	DefaultMode *int32 `json:"defaultMode,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"0","su","sun","sunday","1","mo","mon","monday","2","tu","tue","tuesday","3","we","wed","wednesday","4","th","thu","thursday","5","fr","fri","friday","6","sa","sat","saturday"}

--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -289,8 +289,9 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 			Name: name.SafeConcatName("secret", secret.Name),
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secret.Name,
-					Optional:   pointer.Bool(secret.IgnoreUpdates),
+					SecretName:  secret.Name,
+					DefaultMode: secret.DefaultMode,
+					Optional:    pointer.Bool(secret.IgnoreUpdates),
 				},
 			},
 		})


### PR DESCRIPTION
Rebase of https://github.com/rancher/system-upgrade-controller/pull/337. This will allow setting `defaultMode` on secret mounts. This should be backwards compatible with existing resources.