### PR TITLE
Update Go toolchain to 1.24.6 in all go.mod files to fix CVE-2025-47907

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/system-upgrade-controller
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.6
 
 replace (
 	github.com/distribution/reference => github.com/distribution/reference v0.5.0

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/system-upgrade-controller/pkg/apis
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.6
 
 require (
 	github.com/kubereboot/kured v1.13.1


### PR DESCRIPTION
- Bump toolchain version to go1.24.6 in both root and pkg/apis go.mod files.
- Addresses high severity vulnerability in database/sql (CVE-2025-47907).
- Ensures builds use a secure Go version with the