### PR TITLE
fix: update images to latest tag in manifests

### DIFF
--- a/manifests/system-upgrade-controller.yaml
+++ b/manifests/system-upgrade-controller.yaml
@@ -23,7 +23,7 @@ data:
   SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: "900"
   SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: "99"
   SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: "Always"
-  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: "rancher/kubectl:v1.30.3"
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: "rancher/kubectl:latest"
   SYSTEM_UPGRADE_JOB_PRIVILEGED: "true"
   SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: "900"
   SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: "15m"
@@ -84,7 +84,7 @@ spec:
           effect: "NoExecute"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.16.3
+          image: rancher/system-upgrade-controller:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
Updated the hardcoded image tag for system-upgrade-controller to v0.16.3.

**Notes:**
Please move the tag on master after merging to ensure this change is included in the referenced tag.

---

**UPDATE (2025-10-24):**

Changed approach based on maintainer feedback. Instead of pinning to a specific version, updated both images to `latest` tag:
- `rancher/system-upgrade-controller`: v0.16.3 → latest
- `rancher/kubectl`: v1.30.3 → latest

This ensures YOLO users following the official README installation method get current versions without requiring manual manifest updates.